### PR TITLE
Select Options Based on Form Data

### DIFF
--- a/src/controls/button.rs
+++ b/src/controls/button.rs
@@ -7,13 +7,9 @@ use web_sys::MouseEvent;
 
 type ButtonAction<FD> = dyn Fn(MouseEvent, RwSignal<FD>) + 'static;
 
-/// Data used for the button control.
+/// Data used for the building button control.
 pub struct ButtonBuildData<FD: FormToolData> {
     pub action: Option<Rc<ButtonAction<FD>>>,
-}
-/// Data used for the button control.
-pub struct ButtonData {
-    pub action: Option<Rc<dyn Fn(MouseEvent)>>,
 }
 impl<FD: FormToolData> Default for ButtonBuildData<FD> {
     fn default() -> Self {
@@ -26,6 +22,11 @@ impl<FD: FormToolData> Clone for ButtonBuildData<FD> {
             action: self.action.clone(),
         }
     }
+}
+
+/// Data used for the button control.
+pub struct ButtonData {
+    pub action: Option<Rc<dyn Fn(MouseEvent)>>,
 }
 
 impl<FD: FormToolData> VanityControlData<FD> for ButtonBuildData<FD> {
@@ -70,7 +71,9 @@ impl<FD: FormToolData> FormBuilder<FD> {
 }
 
 impl<FD: FormToolData> VanityControlBuilder<FD, ButtonBuildData<FD>> {
-    /// Sets the text of the button.
+    /// Sets the text of the button to a static string.
+    ///
+    /// For dynamic button text, use the `getter` method.
     pub fn text(mut self, text: impl ToString) -> Self {
         let text = text.to_string();
         self.getter = Some(Rc::new(move |_| text.clone()));

--- a/src/controls/checkbox.rs
+++ b/src/controls/checkbox.rs
@@ -23,7 +23,7 @@ impl<FD: FormToolData> ControlData<FD> for CheckboxData {
         value_setter: SignalSetter<Self::ReturnType>,
         _validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.checkbox::<FD>(control, value_getter, value_setter)
+        fs.checkbox(control, value_getter, value_setter)
     }
 }
 

--- a/src/controls/checkbox.rs
+++ b/src/controls/checkbox.rs
@@ -2,7 +2,7 @@ use super::{
     BuilderCxFn, BuilderFn, ControlBuilder, ControlData, ControlRenderData, ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{Signal, SignalSetter, View};
+use leptos::{RwSignal, Signal, SignalSetter, View};
 use std::rc::Rc;
 
 /// Data used for the checkbox control.
@@ -12,17 +12,18 @@ pub struct CheckboxData {
     pub label: Option<String>,
 }
 
-impl ControlData for CheckboxData {
+impl<FD: FormToolData> ControlData<FD> for CheckboxData {
     type ReturnType = bool;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         _validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.checkbox(control, value_getter, value_setter)
+        fs.checkbox::<FD>(control, value_getter, value_setter)
     }
 }
 

--- a/src/controls/custom.rs
+++ b/src/controls/custom.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a custom component and adds it to the form.
-    pub fn custom<CC: ControlData, FDT: Clone + PartialEq + 'static>(
+    pub fn custom<CC: ControlData<FD>, FDT: Clone + PartialEq + 'static>(
         mut self,
         control_data: CC,
         builder: impl BuilderFn<ControlBuilder<FD, CC, FDT>>,
@@ -20,7 +20,7 @@ impl<FD: FormToolData> FormBuilder<FD> {
 
     /// Builds a custom component using the form's context and adds it to the
     /// form.
-    pub fn custom_cx<CC: ControlData, FDT: Clone + PartialEq + 'static>(
+    pub fn custom_cx<CC: ControlData<FD>, FDT: Clone + PartialEq + 'static>(
         mut self,
         control_data: CC,
         builder: impl BuilderCxFn<ControlBuilder<FD, CC, FDT>, FD::Context>,
@@ -32,7 +32,7 @@ impl<FD: FormToolData> FormBuilder<FD> {
     }
 
     /// Builds a custom vanity component and adds it to the form.
-    pub fn custom_vanity<CC: VanityControlData>(
+    pub fn custom_vanity<CC: VanityControlData<FD>>(
         mut self,
         control_data: CC,
         builder: impl BuilderFn<VanityControlBuilder<FD, CC>>,
@@ -45,7 +45,7 @@ impl<FD: FormToolData> FormBuilder<FD> {
 
     /// Builds a custom vanity component using the form's context and adds it
     /// to the form.
-    pub fn custom_vanity_cx<CC: VanityControlData>(
+    pub fn custom_vanity_cx<CC: VanityControlData<FD>>(
         mut self,
         control_data: CC,
         builder: impl BuilderCxFn<VanityControlBuilder<FD, CC>, FD::Context>,

--- a/src/controls/heading.rs
+++ b/src/controls/heading.rs
@@ -21,16 +21,17 @@ pub struct HeadingData {
     pub level: HeadingLevel,
 }
 
-impl VanityControlData for HeadingData {
-    fn build_control<FS: FormStyle>(
+impl<FD: FormToolData> VanityControlData<FD> for HeadingData {
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: leptos::prelude::RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Option<Signal<String>>,
     ) -> View {
         fs.heading(control, value_getter)
     }
 }
-impl GetterVanityControlData for HeadingData {}
+impl<FD: FormToolData> GetterVanityControlData<FD> for HeadingData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a heading and adds it to the form.

--- a/src/controls/hidden.rs
+++ b/src/controls/hidden.rs
@@ -12,16 +12,17 @@ pub struct HiddenData {
     pub name: String,
 }
 
-impl VanityControlData for HiddenData {
-    fn build_control<FS: FormStyle>(
+impl<FD: FormToolData> VanityControlData<FD> for HiddenData {
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: leptos::prelude::RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Option<Signal<String>>,
     ) -> View {
         fs.hidden(control, value_getter)
     }
 }
-impl GetterVanityControlData for HiddenData {}
+impl<FD: FormToolData> GetterVanityControlData<FD> for HiddenData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a hidden form control and adds it to the form.

--- a/src/controls/mod.rs
+++ b/src/controls/mod.rs
@@ -109,31 +109,33 @@ pub enum UpdateEvent {
 }
 
 /// A trait for the data needed to render an read-only control.
-pub trait VanityControlData: 'static {
+pub trait VanityControlData<FD: FormToolData>: 'static {
     /// Builds the control, returning the [`View`] that was built.
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Option<Signal<String>>,
     ) -> View;
 }
-pub trait GetterVanityControlData: VanityControlData {}
+pub trait GetterVanityControlData<FD: FormToolData>: VanityControlData<FD> {}
 
 /// A trait for the data needed to render an interactive control.
-pub trait ControlData: 'static {
+pub trait ControlData<FD: FormToolData>: 'static {
     /// This is the data type returned by this control.
     type ReturnType: Clone;
 
     /// Builds the control, returning the [`View`] that was built.
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 }
-pub trait ValidatedControlData: ControlData {}
+pub trait ValidatedControlData<FD: FormToolData>: ControlData<FD> {}
 
 /// The data needed to render a interactive control of type `C`.
 pub struct ControlRenderData<FS: FormStyle + ?Sized, C: ?Sized> {
@@ -142,20 +144,20 @@ pub struct ControlRenderData<FS: FormStyle + ?Sized, C: ?Sized> {
 }
 
 /// The data needed to render a read-only control of type `C`.
-pub struct VanityControlBuilder<FD: FormToolData, C: VanityControlData> {
+pub struct VanityControlBuilder<FD: FormToolData, C: VanityControlData<FD>> {
     pub(crate) style_attributes: Vec<<FD::Style as FormStyle>::StylingAttributes>,
     pub(crate) data: C,
     pub(crate) getter: Option<Rc<dyn FieldGetter<FD, String>>>,
     pub(crate) show_when: Option<Box<dyn ShowWhenFn<FD, FD::Context>>>,
 }
 
-pub(crate) struct BuiltVanityControlData<FD: FormToolData, C: VanityControlData> {
+pub(crate) struct BuiltVanityControlData<FD: FormToolData, C: VanityControlData<FD>> {
     pub(crate) render_data: ControlRenderData<FD::Style, C>,
     pub(crate) getter: Option<Rc<dyn FieldGetter<FD, String>>>,
     pub(crate) show_when: Option<Box<dyn ShowWhenFn<FD, FD::Context>>>,
 }
 
-impl<FD: FormToolData, C: VanityControlData> VanityControlBuilder<FD, C> {
+impl<FD: FormToolData, C: VanityControlData<FD>> VanityControlBuilder<FD, C> {
     /// Creates a new [`VanityControlBuilder`] with the given [`VanityControlData`].
     pub(crate) fn new(data: C) -> Self {
         VanityControlBuilder {
@@ -196,7 +198,7 @@ impl<FD: FormToolData, C: VanityControlData> VanityControlBuilder<FD, C> {
     }
 }
 
-impl<FD: FormToolData, C: GetterVanityControlData> VanityControlBuilder<FD, C> {
+impl<FD: FormToolData, C: GetterVanityControlData<FD>> VanityControlBuilder<FD, C> {
     /// Sets the getter function.
     ///
     /// This function can get a string from the form data to be displayed
@@ -232,8 +234,8 @@ impl Display for ControlBuildError {
     }
 }
 
-/// The data returned fomr a control's build function.
-pub(crate) struct BuiltControlData<FD: FormToolData, C: ControlData, FDT> {
+/// The data returned from a control's build function.
+pub(crate) struct BuiltControlData<FD: FormToolData, C: ControlData<FD>, FDT> {
     pub(crate) render_data: ControlRenderData<FD::Style, C>,
     pub(crate) getter: Rc<dyn FieldGetter<FD, FDT>>,
     pub(crate) setter: Rc<dyn FieldSetter<FD, FDT>>,
@@ -244,7 +246,7 @@ pub(crate) struct BuiltControlData<FD: FormToolData, C: ControlData, FDT> {
 }
 
 /// A builder for a interactive control.
-pub struct ControlBuilder<FD: FormToolData, C: ControlData, FDT> {
+pub struct ControlBuilder<FD: FormToolData, C: ControlData<FD>, FDT> {
     pub(crate) getter: Option<Rc<dyn FieldGetter<FD, FDT>>>,
     pub(crate) setter: Option<Rc<dyn FieldSetter<FD, FDT>>>,
     pub(crate) parse_fn: Option<Box<dyn ParseFn<C::ReturnType, FDT>>>,
@@ -255,7 +257,7 @@ pub struct ControlBuilder<FD: FormToolData, C: ControlData, FDT> {
     pub data: C,
 }
 
-impl<FD: FormToolData, C: ControlData, FDT> ControlBuilder<FD, C, FDT> {
+impl<FD: FormToolData, C: ControlData<FD>, FDT> ControlBuilder<FD, C, FDT> {
     /// Creates a new [`ControlBuilder`] with the given [`ControlData`].
     pub(crate) fn new(data: C) -> Self {
         ControlBuilder {
@@ -363,10 +365,10 @@ impl<FD: FormToolData, C: ControlData, FDT> ControlBuilder<FD, C, FDT> {
 impl<FD, C, FDT> ControlBuilder<FD, C, FDT>
 where
     FD: FormToolData,
-    C: ControlData,
-    FDT: TryFrom<<C as ControlData>::ReturnType>,
-    <FDT as TryFrom<<C as ControlData>::ReturnType>>::Error: ToString,
-    <C as ControlData>::ReturnType: From<FDT>,
+    C: ControlData<FD>,
+    FDT: TryFrom<<C as ControlData<FD>>::ReturnType>,
+    <FDT as TryFrom<<C as ControlData<FD>>::ReturnType>>::Error: ToString,
+    <C as ControlData<FD>>::ReturnType: From<FDT>,
 {
     /// Sets the parse functions to use the [`TryFrom`] and [`From`] traits
     /// for parsing and unparsing respectively.
@@ -379,7 +381,7 @@ where
             FDT::try_from(control_return_value).map_err(|e| e.to_string())
         }));
         self.unparse_fn = Some(Box::new(|field| {
-            <C as ControlData>::ReturnType::from(field)
+            <C as ControlData<FD>>::ReturnType::from(field)
         }));
         self
     }
@@ -388,9 +390,9 @@ where
 impl<FD, C, FDT> ControlBuilder<FD, C, FDT>
 where
     FD: FormToolData,
-    C: ControlData,
-    FDT: TryFrom<<C as ControlData>::ReturnType>,
-    <C as ControlData>::ReturnType: From<FDT>,
+    C: ControlData<FD>,
+    FDT: TryFrom<<C as ControlData<FD>>::ReturnType>,
+    <C as ControlData<FD>>::ReturnType: From<FDT>,
 {
     /// Sets the parse functions to use the [`TryFrom`] and [`From`] traits
     /// for parsing and unparsing respectively, with a custom error message.
@@ -403,7 +405,7 @@ where
             FDT::try_from(control_return_value).map_err(|_| msg.to_string())
         }));
         self.unparse_fn = Some(Box::new(|field| {
-            <C as ControlData>::ReturnType::from(field)
+            <C as ControlData<FD>>::ReturnType::from(field)
         }));
         self
     }
@@ -412,7 +414,7 @@ where
 impl<FD, C, FDT> ControlBuilder<FD, C, FDT>
 where
     FD: FormToolData,
-    C: ControlData<ReturnType = String>,
+    C: ControlData<FD, ReturnType = String>,
     FDT: FromStr + ToString,
     <FDT as FromStr>::Err: ToString,
 {
@@ -494,7 +496,7 @@ where
 impl<FD, C, FDT> ControlBuilder<FD, C, Option<FDT>>
 where
     FD: FormToolData,
-    C: ControlData<ReturnType = String>,
+    C: ControlData<FD, ReturnType = String>,
     FDT: FromStr + ToString,
 {
     /// Sets the parse functions to use the [`FromStr`] [`ToString`] and traits
@@ -540,7 +542,7 @@ where
 impl<FD, C, FDT> ControlBuilder<FD, C, FDT>
 where
     FD: FormToolData,
-    C: ControlData<ReturnType = String>,
+    C: ControlData<FD, ReturnType = String>,
     FDT: FromStr + ToString + Default,
 {
     /// Sets the parse functions to use the [`FromStr`] [`ToString`] and traits
@@ -581,7 +583,7 @@ where
     }
 }
 
-impl<FD: FormToolData, C: ValidatedControlData, FDT> ControlBuilder<FD, C, FDT> {
+impl<FD: FormToolData, C: ValidatedControlData<FD>, FDT> ControlBuilder<FD, C, FDT> {
     /// Sets the validation function for this control
     ///
     /// This allows you to check if the parsed value is a valid value.

--- a/src/controls/mod.rs
+++ b/src/controls/mod.rs
@@ -122,7 +122,7 @@ pub trait GetterVanityControlData<FD: FormToolData>: VanityControlData<FD> {}
 
 /// A trait for the data needed to render an interactive control.
 pub trait ControlData<FD: FormToolData>: 'static {
-    /// This is the data type returned by this control.
+    /// This is the data type returned by this control. Usually a [`String`].
     type ReturnType: Clone;
 
     /// Builds the control, returning the [`View`] that was built.

--- a/src/controls/output.rs
+++ b/src/controls/output.rs
@@ -3,23 +3,24 @@ use super::{
     VanityControlData,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{Signal, View};
+use leptos::{RwSignal, Signal, View};
 use std::rc::Rc;
 
 /// Data used for the output control.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct OutputData;
 
-impl VanityControlData for OutputData {
-    fn build_control<FS: FormStyle>(
+impl<FD: FormToolData> VanityControlData<FD> for OutputData {
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Option<Signal<String>>,
     ) -> View {
         fs.output(control, value_getter)
     }
 }
-impl GetterVanityControlData for OutputData {}
+impl<FD: FormToolData> GetterVanityControlData<FD> for OutputData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds an output form control and adds it to the form.

--- a/src/controls/radio_buttons.rs
+++ b/src/controls/radio_buttons.rs
@@ -28,7 +28,7 @@ impl<FD: FormToolData> ControlData<FD> for RadioButtonsData {
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.radio_buttons::<FD>(control, value_getter, value_setter, validation_state)
+        fs.radio_buttons(control, value_getter, value_setter, validation_state)
     }
 }
 impl<FD: FormToolData> ValidatedControlData<FD> for RadioButtonsData {}

--- a/src/controls/radio_buttons.rs
+++ b/src/controls/radio_buttons.rs
@@ -3,7 +3,7 @@ use super::{
     ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{Signal, SignalSetter, View};
+use leptos::{RwSignal, Signal, SignalSetter, View};
 use std::rc::Rc;
 
 /// Data used for the radio buttons control.
@@ -17,20 +17,21 @@ pub struct RadioButtonsData {
     pub options: Vec<(String, String)>,
 }
 
-impl ControlData for RadioButtonsData {
+impl<FD: FormToolData> ControlData<FD> for RadioButtonsData {
     type ReturnType = String;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.radio_buttons(control, value_getter, value_setter, validation_state)
+        fs.radio_buttons::<FD>(control, value_getter, value_setter, validation_state)
     }
 }
-impl ValidatedControlData for RadioButtonsData {}
+impl<FD: FormToolData> ValidatedControlData<FD> for RadioButtonsData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a radio buttons control and adds it to the form.

--- a/src/controls/select.rs
+++ b/src/controls/select.rs
@@ -3,11 +3,37 @@ use super::{
     ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{IntoSignal, MaybeSignal, Signal, SignalGet, SignalSetter, View};
+use leptos::{IntoSignal, MaybeSignal, RwSignal, Signal, SignalGet, SignalSetter, View};
 use std::rc::Rc;
 
+/// Data used for building the select control.
+pub struct SelectBuildData<FD: FormToolData> {
+    pub name: String,
+    pub label: Option<String>,
+    /// A derived signal for dynamic options for the select
+    ///
+    /// This is just a temp value for building, and should not be used
+    /// directly
+    dynamic_options: Option<Rc<dyn Fn(RwSignal<FD>) -> Vec<(String, String)> + 'static>>,
+    /// The options for the select.
+    ///
+    /// The first value is the string to display, the second is the value.
+    pub options: MaybeSignal<Vec<(String, String)>>,
+    /// The display text for the blank option, if there is one.
+    pub blank_option: Option<String>,
+}
+impl<FD: FormToolData> Default for SelectBuildData<FD> {
+    fn default() -> Self {
+        SelectBuildData {
+            name: String::default(),
+            label: None,
+            dynamic_options: None,
+            options: MaybeSignal::default(),
+            blank_option: None,
+        }
+    }
+}
 /// Data used for the select control.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SelectData {
     pub name: String,
     pub label: Option<String>,
@@ -19,26 +45,50 @@ pub struct SelectData {
     pub blank_option: Option<String>,
 }
 
-impl ControlData for SelectData {
+impl<FD: FormToolData> ControlData<FD> for SelectBuildData<FD> {
     type ReturnType = String;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        fd: RwSignal<FD>,
+        // TODO: does control need to be RC'ed at this point?
+        //       Button and select are having to rebuild them.
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.select(control, value_getter, value_setter, validation_state)
+        let options = control
+            .data
+            .dynamic_options
+            .as_ref()
+            .map(|d| {
+                let d = d.clone();
+                MaybeSignal::Dynamic((move || d(fd)).into_signal())
+            })
+            .unwrap_or(control.data.options.clone());
+
+        let new_control = ControlRenderData {
+            styles: control.styles.clone(),
+            data: SelectData {
+                name: control.data.name.clone(),
+                label: control.data.label.clone(),
+                options,
+                blank_option: control.data.blank_option.clone(),
+            },
+        };
+        let new_control = Rc::new(new_control);
+
+        fs.select::<FD>(new_control, value_getter, value_setter, validation_state)
     }
 }
-impl ValidatedControlData for SelectData {}
+impl<FD: FormToolData> ValidatedControlData<FD> for SelectBuildData<FD> {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a select control and adds it to the form.
     pub fn select<FDT: Clone + PartialEq + 'static>(
         self,
-        builder: impl BuilderFn<ControlBuilder<FD, SelectData, FDT>>,
+        builder: impl BuilderFn<ControlBuilder<FD, SelectBuildData<FD>, FDT>>,
     ) -> Self {
         self.new_control(builder)
     }
@@ -47,13 +97,13 @@ impl<FD: FormToolData> FormBuilder<FD> {
     /// form.
     pub fn select_cx<FDT: Clone + PartialEq + 'static>(
         self,
-        builder: impl BuilderCxFn<ControlBuilder<FD, SelectData, FDT>, FD::Context>,
+        builder: impl BuilderCxFn<ControlBuilder<FD, SelectBuildData<FD>, FDT>, FD::Context>,
     ) -> Self {
         self.new_control_cx(builder)
     }
 }
 
-impl<FD: FormToolData, FDT> ControlBuilder<FD, SelectData, FDT> {
+impl<FD: FormToolData, FDT> ControlBuilder<FD, SelectBuildData<FD>, FDT> {
     /// Sets the name of the radio button inputs.
     ///
     /// This is used for the html element's "name" attribute.
@@ -74,6 +124,9 @@ impl<FD: FormToolData, FDT> ControlBuilder<FD, SelectData, FDT> {
     ///
     /// This will overwrite any pervious options setting.
     pub fn with_options(mut self, options: impl Iterator<Item = impl ToString>) -> Self {
+        // clear dynamic option
+        self.data.dynamic_options = None;
+
         let options = options.map(|v| (v.to_string(), v.to_string())).collect();
         self.data.options = MaybeSignal::Static(options);
         self
@@ -87,6 +140,9 @@ impl<FD: FormToolData, FDT> ControlBuilder<FD, SelectData, FDT> {
         mut self,
         options: impl Iterator<Item = (impl ToString, impl ToString)>,
     ) -> Self {
+        // clear dynamic option
+        self.data.dynamic_options = None;
+
         let options = options
             .map(|(d, v)| (d.to_string(), v.to_string()))
             .collect();
@@ -98,6 +154,9 @@ impl<FD: FormToolData, FDT> ControlBuilder<FD, SelectData, FDT> {
     ///
     /// This will overwrite any pervious options setting.
     pub fn with_options_signal(mut self, options: Signal<Vec<String>>) -> Self {
+        // clear dynamic option
+        self.data.dynamic_options = None;
+
         let options = move || {
             options
                 .get()
@@ -114,7 +173,45 @@ impl<FD: FormToolData, FDT> ControlBuilder<FD, SelectData, FDT> {
     ///
     /// This will overwrite any pervious options setting.
     pub fn with_options_valued_signal(mut self, options: Signal<Vec<(String, String)>>) -> Self {
+        // clear dynamic option
+        self.data.dynamic_options = None;
+
         self.data.options = MaybeSignal::Dynamic(options);
+        self
+    }
+
+    /// Sets the options to the given derived signal.
+    ///
+    /// This will overwrite any pervious options setting.
+    pub fn with_dynamic_options(
+        mut self,
+        derived_signal: impl Fn(RwSignal<FD>) -> Vec<String> + 'static,
+    ) -> Self {
+        let derived_signal = move |fd| {
+            derived_signal(fd)
+                .into_iter()
+                .map(|v| (v.clone(), v))
+                .collect::<Vec<_>>()
+        };
+        self.data.dynamic_options = Some(Rc::new(derived_signal));
+        self
+    }
+
+    /// Sets the options to the (display_string, value) pairs from the
+    /// provided derived signal.
+    ///
+    /// This will overwrite any pervious options setting.
+    pub fn with_dynamic_options_valued(
+        mut self,
+        derived_signal: impl Fn(RwSignal<FD>) -> Vec<String> + 'static,
+    ) -> Self {
+        let derived_signal = move |fd| {
+            derived_signal(fd)
+                .into_iter()
+                .map(|v| (v.clone(), v))
+                .collect::<Vec<_>>()
+        };
+        self.data.dynamic_options = Some(Rc::new(derived_signal));
         self
     }
 

--- a/src/controls/select.rs
+++ b/src/controls/select.rs
@@ -33,7 +33,20 @@ impl<FD: FormToolData> Default for SelectBuildData<FD> {
         }
     }
 }
+impl<FD: FormToolData> Clone for SelectBuildData<FD> {
+    fn clone(&self) -> Self {
+        SelectBuildData {
+            name: self.name.clone(),
+            label: self.label.clone(),
+            dynamic_options: self.dynamic_options.clone(),
+            options: self.options.clone(),
+            blank_option: self.blank_option.clone(),
+        }
+    }
+}
+
 /// Data used for the select control.
+#[derive(Default, Clone)]
 pub struct SelectData {
     pub name: String,
     pub label: Option<String>,
@@ -51,8 +64,6 @@ impl<FD: FormToolData> ControlData<FD> for SelectBuildData<FD> {
     fn render_control<FS: FormStyle>(
         fs: &FS,
         fd: RwSignal<FD>,
-        // TODO: does control need to be RC'ed at this point?
-        //       Button and select are having to rebuild them.
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
@@ -79,7 +90,7 @@ impl<FD: FormToolData> ControlData<FD> for SelectBuildData<FD> {
         };
         let new_control = Rc::new(new_control);
 
-        fs.select::<FD>(new_control, value_getter, value_setter, validation_state)
+        fs.select(new_control, value_getter, value_setter, validation_state)
     }
 }
 impl<FD: FormToolData> ValidatedControlData<FD> for SelectBuildData<FD> {}

--- a/src/controls/slider.rs
+++ b/src/controls/slider.rs
@@ -2,7 +2,7 @@ use super::{
     BuilderCxFn, BuilderFn, ControlBuilder, ControlData, ControlRenderData, ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{MaybeSignal, Signal, SignalSetter, View};
+use leptos::{MaybeSignal, RwSignal, Signal, SignalSetter, View};
 use std::rc::Rc;
 
 /// Data used for the slider control.
@@ -25,17 +25,18 @@ impl Default for SliderData {
     }
 }
 
-impl ControlData for SliderData {
+impl<FD: FormToolData> ControlData<FD> for SliderData {
     type ReturnType = i32;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.slider(control, value_getter, value_setter, validation_state)
+        fs.slider::<FD>(control, value_getter, value_setter, validation_state)
     }
 }
 

--- a/src/controls/slider.rs
+++ b/src/controls/slider.rs
@@ -10,8 +10,9 @@ use std::rc::Rc;
 pub struct SliderData {
     pub name: String,
     pub label: Option<String>,
-    pub min: MaybeSignal<i32>,
-    pub max: MaybeSignal<i32>,
+    pub step: Option<MaybeSignal<String>>,
+    pub min: Option<MaybeSignal<String>>,
+    pub max: Option<MaybeSignal<String>>,
 }
 
 impl Default for SliderData {
@@ -19,14 +20,16 @@ impl Default for SliderData {
         SliderData {
             name: String::new(),
             label: None,
-            min: MaybeSignal::Static(0),
-            max: MaybeSignal::Static(1),
+            step: None,
+            min: None,
+            max: None,
         }
     }
 }
 
 impl<FD: FormToolData> ControlData<FD> for SliderData {
-    type ReturnType = i32;
+    /// String to support integers or decimal point types.
+    type ReturnType = String;
 
     fn render_control<FS: FormStyle>(
         fs: &FS,
@@ -36,7 +39,7 @@ impl<FD: FormToolData> ControlData<FD> for SliderData {
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.slider::<FD>(control, value_getter, value_setter, validation_state)
+        fs.slider(control, value_getter, value_setter, validation_state)
     }
 }
 
@@ -76,27 +79,39 @@ impl<FD: FormToolData, FDT> ControlBuilder<FD, SliderData, FDT> {
         self
     }
 
+    /// Sets the step ammount.
+    pub fn step(mut self, step: impl ToString) -> Self {
+        self.data.step = Some(MaybeSignal::Static(step.to_string()));
+        self
+    }
+
+    /// Sets the step ammount to a signal.
+    pub fn step_signal(mut self, step: Signal<String>) -> Self {
+        self.data.step = Some(MaybeSignal::Dynamic(step));
+        self
+    }
+
     /// Sets the minimum value for the slider.
-    pub fn min(mut self, min: i32) -> Self {
-        self.data.min = MaybeSignal::Static(min);
+    pub fn min(mut self, min: impl ToString) -> Self {
+        self.data.min = Some(MaybeSignal::Static(min.to_string()));
         self
     }
 
     /// Sets the minimum value for the slider to a signal.
-    pub fn min_signal(mut self, min: Signal<i32>) -> Self {
-        self.data.min = MaybeSignal::Dynamic(min);
+    pub fn min_signal(mut self, min: Signal<String>) -> Self {
+        self.data.min = Some(MaybeSignal::Dynamic(min));
         self
     }
 
     /// Sets the maximum value for the slider.
-    pub fn max(mut self, max: i32) -> Self {
-        self.data.max = MaybeSignal::Static(max);
+    pub fn max(mut self, max: impl ToString) -> Self {
+        self.data.max = Some(MaybeSignal::Static(max.to_string()));
         self
     }
 
     /// Sets the maximum value for the slider to a signal.
-    pub fn max_signal(mut self, max: Signal<i32>) -> Self {
-        self.data.max = MaybeSignal::Dynamic(max);
+    pub fn max_signal(mut self, max: Signal<String>) -> Self {
+        self.data.max = Some(MaybeSignal::Dynamic(max));
         self
     }
 }

--- a/src/controls/spacer.rs
+++ b/src/controls/spacer.rs
@@ -1,6 +1,6 @@
 use super::{BuilderCxFn, BuilderFn, ControlRenderData, VanityControlBuilder, VanityControlData};
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{prelude::Signal, View};
+use leptos::{prelude::Signal, RwSignal, View};
 use std::rc::Rc;
 
 /// Data used for the spacer control.
@@ -9,9 +9,10 @@ pub struct SpacerData {
     pub height: Option<String>,
 }
 
-impl VanityControlData for SpacerData {
-    fn build_control<FS: FormStyle>(
+impl<FD: FormToolData> VanityControlData<FD> for SpacerData {
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         _value_getter: Option<Signal<String>>,
     ) -> View {

--- a/src/controls/stepper.rs
+++ b/src/controls/stepper.rs
@@ -11,12 +11,13 @@ use std::rc::Rc;
 pub struct StepperData {
     pub name: String,
     pub label: Option<String>,
-    pub step: Option<MaybeSignal<i32>>,
-    pub min: Option<MaybeSignal<i32>>,
-    pub max: Option<MaybeSignal<i32>>,
+    pub step: Option<MaybeSignal<String>>,
+    pub min: Option<MaybeSignal<String>>,
+    pub max: Option<MaybeSignal<String>>,
 }
 
 impl<FD: FormToolData> ControlData<FD> for StepperData {
+    /// String, as a user can still enter characters in a number fields.
     type ReturnType = String;
 
     fn render_control<FS: FormStyle>(
@@ -27,7 +28,7 @@ impl<FD: FormToolData> ControlData<FD> for StepperData {
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.stepper::<FD>(control, value_getter, value_setter, validation_state)
+        fs.stepper(control, value_getter, value_setter, validation_state)
     }
 }
 impl<FD: FormToolData> ValidatedControlData<FD> for StepperData {}
@@ -69,37 +70,37 @@ impl<FD: FormToolData, FDT> ControlBuilder<FD, StepperData, FDT> {
     }
 
     /// Sets the step ammount.
-    pub fn step(mut self, step: i32) -> Self {
-        self.data.step = Some(MaybeSignal::Static(step));
+    pub fn step(mut self, step: impl ToString) -> Self {
+        self.data.step = Some(MaybeSignal::Static(step.to_string()));
         self
     }
 
-    /// Sets the step ammount.
-    pub fn step_signal(mut self, step: Signal<i32>) -> Self {
+    /// Sets the step ammount to a signal.
+    pub fn step_signal(mut self, step: Signal<String>) -> Self {
         self.data.step = Some(MaybeSignal::Dynamic(step));
         self
     }
 
-    /// Sets the minimum value for the slider.
-    pub fn min(mut self, min: i32) -> Self {
-        self.data.min = Some(MaybeSignal::Static(min));
+    /// Sets the minimum value for the stepper.
+    pub fn min(mut self, min: impl ToString) -> Self {
+        self.data.min = Some(MaybeSignal::Static(min.to_string()));
         self
     }
 
-    /// Sets the minimum value for the slider to a signal.
-    pub fn min_signal(mut self, min: Signal<i32>) -> Self {
+    /// Sets the minimum value for the stepper to a signal.
+    pub fn min_signal(mut self, min: Signal<String>) -> Self {
         self.data.min = Some(MaybeSignal::Dynamic(min));
         self
     }
 
-    /// Sets the maximum value for the slider.
-    pub fn max(mut self, max: i32) -> Self {
-        self.data.max = Some(MaybeSignal::Static(max));
+    /// Sets the maximum value for the stepper.
+    pub fn max(mut self, max: impl ToString) -> Self {
+        self.data.max = Some(MaybeSignal::Static(max.to_string()));
         self
     }
 
-    /// Sets the maximum value for the slider to a signal.
-    pub fn max_signal(mut self, max: Signal<i32>) -> Self {
+    /// Sets the maximum value for the stepper to a signal.
+    pub fn max_signal(mut self, max: Signal<String>) -> Self {
         self.data.max = Some(MaybeSignal::Dynamic(max));
         self
     }

--- a/src/controls/stepper.rs
+++ b/src/controls/stepper.rs
@@ -3,7 +3,7 @@ use super::{
     ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{MaybeSignal, Signal, SignalSetter, View};
+use leptos::{MaybeSignal, RwSignal, Signal, SignalSetter, View};
 use std::rc::Rc;
 
 /// Data used for the stepper control.
@@ -16,20 +16,21 @@ pub struct StepperData {
     pub max: Option<MaybeSignal<i32>>,
 }
 
-impl ControlData for StepperData {
+impl<FD: FormToolData> ControlData<FD> for StepperData {
     type ReturnType = String;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.stepper(control, value_getter, value_setter, validation_state)
+        fs.stepper::<FD>(control, value_getter, value_setter, validation_state)
     }
 }
-impl ValidatedControlData for StepperData {}
+impl<FD: FormToolData> ValidatedControlData<FD> for StepperData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a stepper control and adds it to the form.

--- a/src/controls/submit.rs
+++ b/src/controls/submit.rs
@@ -8,9 +8,7 @@ use std::rc::Rc;
 
 /// Data used for the submit button control.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct SubmitData {
-    pub text: String,
-}
+pub struct SubmitData;
 
 impl<FD: FormToolData> VanityControlData<FD> for SubmitData {
     fn render_control<FS: FormStyle>(
@@ -41,7 +39,9 @@ impl<FD: FormToolData> FormBuilder<FD> {
 }
 
 impl<FD: FormToolData> VanityControlBuilder<FD, SubmitData> {
-    /// Sets the submit button's text.
+    /// Sets the text of the submit button to a static string.
+    ///
+    /// For dynamic button text, use the `getter` method.
     pub fn text(mut self, text: impl ToString) -> Self {
         let text = text.to_string();
         self.getter = Some(Rc::new(move |_| text.clone()));

--- a/src/controls/submit.rs
+++ b/src/controls/submit.rs
@@ -3,7 +3,7 @@ use super::{
     VanityControlData,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{prelude::Signal, View};
+use leptos::{prelude::Signal, RwSignal, View};
 use std::rc::Rc;
 
 /// Data used for the submit button control.
@@ -12,16 +12,17 @@ pub struct SubmitData {
     pub text: String,
 }
 
-impl VanityControlData for SubmitData {
-    fn build_control<FS: FormStyle>(
+impl<FD: FormToolData> VanityControlData<FD> for SubmitData {
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Option<Signal<String>>,
     ) -> View {
         fs.submit(control, value_getter)
     }
 }
-impl GetterVanityControlData for SubmitData {}
+impl<FD: FormToolData> GetterVanityControlData<FD> for SubmitData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a submit button and adds it to the form.

--- a/src/controls/text_area.rs
+++ b/src/controls/text_area.rs
@@ -3,7 +3,7 @@ use super::{
     ValidatedControlData, ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{Signal, SignalSetter, View};
+use leptos::{RwSignal, Signal, SignalSetter, View};
 use std::rc::Rc;
 
 /// Data used for the text area control.
@@ -15,20 +15,21 @@ pub struct TextAreaData {
     pub update_event: UpdateEvent,
 }
 
-impl ControlData for TextAreaData {
+impl<FD: FormToolData> ControlData<FD> for TextAreaData {
     type ReturnType = String;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.text_area(control, value_getter, value_setter, validation_state)
+        fs.text_area::<FD>(control, value_getter, value_setter, validation_state)
     }
 }
-impl ValidatedControlData for TextAreaData {}
+impl<FD: FormToolData> ValidatedControlData<FD> for TextAreaData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a text area control and adds it to the form.

--- a/src/controls/text_area.rs
+++ b/src/controls/text_area.rs
@@ -26,7 +26,7 @@ impl<FD: FormToolData> ControlData<FD> for TextAreaData {
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.text_area::<FD>(control, value_getter, value_setter, validation_state)
+        fs.text_area(control, value_getter, value_setter, validation_state)
     }
 }
 impl<FD: FormToolData> ValidatedControlData<FD> for TextAreaData {}

--- a/src/controls/text_input.rs
+++ b/src/controls/text_input.rs
@@ -3,7 +3,7 @@ use super::{
     ValidatedControlData, ValidationState,
 };
 use crate::{form::FormToolData, form_builder::FormBuilder, styles::FormStyle};
-use leptos::{Signal, SignalSetter, View};
+use leptos::{RwSignal, Signal, SignalSetter, View};
 use std::rc::Rc;
 
 /// Data used for the text input control.
@@ -28,20 +28,21 @@ impl Default for TextInputData {
     }
 }
 
-impl ControlData for TextInputData {
+impl<FD: FormToolData> ControlData<FD> for TextInputData {
     type ReturnType = String;
 
-    fn build_control<FS: FormStyle>(
+    fn render_control<FS: FormStyle>(
         fs: &FS,
+        _fd: RwSignal<FD>,
         control: Rc<ControlRenderData<FS, Self>>,
         value_getter: Signal<Self::ReturnType>,
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.text_input(control, value_getter, value_setter, validation_state)
+        fs.text_input::<FD>(control, value_getter, value_setter, validation_state)
     }
 }
-impl ValidatedControlData for TextInputData {}
+impl<FD: FormToolData> ValidatedControlData<FD> for TextInputData {}
 
 impl<FD: FormToolData> FormBuilder<FD> {
     /// Builds a text input control and adds it to the form.

--- a/src/controls/text_input.rs
+++ b/src/controls/text_input.rs
@@ -39,7 +39,7 @@ impl<FD: FormToolData> ControlData<FD> for TextInputData {
         value_setter: SignalSetter<Self::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
-        fs.text_input::<FD>(control, value_getter, value_setter, validation_state)
+        fs.text_input(control, value_getter, value_setter, validation_state)
     }
 }
 impl<FD: FormToolData> ValidatedControlData<FD> for TextInputData {}

--- a/src/styles/grid_form.rs
+++ b/src/styles/grid_form.rs
@@ -1,11 +1,20 @@
 use super::FormStyle;
 use crate::{
     controls::{
-        button::ButtonData, checkbox::CheckboxData, heading::HeadingData, hidden::HiddenData,
-        output::OutputData, radio_buttons::RadioButtonsData, select::SelectData,
-        slider::SliderData, spacer::SpacerData, stepper::StepperData, submit::SubmitData,
-        text_area::TextAreaData, text_input::TextInputData, ControlData, ControlRenderData,
-        UpdateEvent, ValidationState,
+        button::ButtonData,
+        checkbox::CheckboxData,
+        heading::HeadingData,
+        hidden::HiddenData,
+        output::OutputData,
+        radio_buttons::RadioButtonsData,
+        select::{SelectBuildData, SelectData},
+        slider::SliderData,
+        spacer::SpacerData,
+        stepper::StepperData,
+        submit::SubmitData,
+        text_area::TextAreaData,
+        text_input::TextInputData,
+        ControlData, ControlRenderData, UpdateEvent, ValidationState,
     },
     FormToolData,
 };
@@ -105,16 +114,15 @@ impl FormStyle for GridFormStyle {
         )
     }
 
-    fn button<FD: FormToolData>(
+    fn button(
         &self,
-        control: Rc<ControlRenderData<Self, ButtonData<FD>>>,
-        data_signal: RwSignal<FD>,
+        control: Rc<ControlRenderData<Self, ButtonData>>,
         value_getter: Option<Signal<String>>,
     ) -> View {
         let action = control.data.action.clone();
         let on_click = move |ev: MouseEvent| {
-            if let Some(action) = action.clone() {
-                action(ev, data_signal)
+            if let Some(ref action) = action {
+                action(ev)
             }
         };
 
@@ -155,11 +163,11 @@ impl FormStyle for GridFormStyle {
         .into_view()
     }
 
-    fn text_input(
+    fn text_input<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, TextInputData>>,
-        value_getter: Signal<<TextInputData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<TextInputData as ControlData>::ReturnType>,
+        value_getter: Signal<<TextInputData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<TextInputData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let input = view! {
@@ -200,11 +208,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn text_area(
+    fn text_area<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, TextAreaData>>,
-        value_getter: Signal<<TextAreaData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<TextAreaData as ControlData>::ReturnType>,
+        value_getter: Signal<<TextAreaData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<TextAreaData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let input = view! {
@@ -245,11 +253,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn radio_buttons(
+    fn radio_buttons<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, RadioButtonsData>>,
-        value_getter: Signal<<RadioButtonsData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<RadioButtonsData as ControlData>::ReturnType>,
+        value_getter: Signal<<RadioButtonsData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<RadioButtonsData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let buttons_view = control
@@ -302,11 +310,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn select(
+    fn select<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, SelectData>>,
-        value_getter: Signal<<SelectData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<SelectData as ControlData>::ReturnType>,
+        value_getter: Signal<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let control_clone = control.clone();
@@ -361,11 +369,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn checkbox(
+    fn checkbox<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, CheckboxData>>,
-        value_getter: Signal<<CheckboxData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<CheckboxData as ControlData>::ReturnType>,
+        value_getter: Signal<<CheckboxData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<CheckboxData as ControlData<FD>>::ReturnType>,
     ) -> View {
         let label = control
             .data
@@ -399,11 +407,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn stepper(
+    fn stepper<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, StepperData>>,
-        value_getter: Signal<<StepperData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<StepperData as ControlData>::ReturnType>,
+        value_getter: Signal<<StepperData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<StepperData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let view = view! {
@@ -433,11 +441,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn slider(
+    fn slider<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, SliderData>>,
-        value_getter: Signal<<SliderData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<SliderData as ControlData>::ReturnType>,
+        value_getter: Signal<<SliderData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<SliderData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let view = view! {

--- a/src/styles/grid_form.rs
+++ b/src/styles/grid_form.rs
@@ -1,22 +1,9 @@
 use super::FormStyle;
-use crate::{
-    controls::{
-        button::ButtonData,
-        checkbox::CheckboxData,
-        heading::HeadingData,
-        hidden::HiddenData,
-        output::OutputData,
-        radio_buttons::RadioButtonsData,
-        select::{SelectBuildData, SelectData},
-        slider::SliderData,
-        spacer::SpacerData,
-        stepper::StepperData,
-        submit::SubmitData,
-        text_area::TextAreaData,
-        text_input::TextInputData,
-        ControlData, ControlRenderData, UpdateEvent, ValidationState,
-    },
-    FormToolData,
+use crate::controls::{
+    button::ButtonData, checkbox::CheckboxData, heading::HeadingData, hidden::HiddenData,
+    output::OutputData, radio_buttons::RadioButtonsData, select::SelectData, slider::SliderData,
+    spacer::SpacerData, stepper::StepperData, submit::SubmitData, text_area::TextAreaData,
+    text_input::TextInputData, ControlRenderData, UpdateEvent, ValidationState,
 };
 use leptos::*;
 use std::rc::Rc;
@@ -163,11 +150,11 @@ impl FormStyle for GridFormStyle {
         .into_view()
     }
 
-    fn text_input<FD: FormToolData>(
+    fn text_input(
         &self,
         control: Rc<ControlRenderData<Self, TextInputData>>,
-        value_getter: Signal<<TextInputData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<TextInputData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let input = view! {
@@ -208,11 +195,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn text_area<FD: FormToolData>(
+    fn text_area(
         &self,
         control: Rc<ControlRenderData<Self, TextAreaData>>,
-        value_getter: Signal<<TextAreaData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<TextAreaData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let input = view! {
@@ -253,11 +240,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn radio_buttons<FD: FormToolData>(
+    fn radio_buttons(
         &self,
         control: Rc<ControlRenderData<Self, RadioButtonsData>>,
-        value_getter: Signal<<RadioButtonsData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<RadioButtonsData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let buttons_view = control
@@ -310,11 +297,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn select<FD: FormToolData>(
+    fn select(
         &self,
         control: Rc<ControlRenderData<Self, SelectData>>,
-        value_getter: Signal<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let control_clone = control.clone();
@@ -369,11 +356,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn checkbox<FD: FormToolData>(
+    fn checkbox(
         &self,
         control: Rc<ControlRenderData<Self, CheckboxData>>,
-        value_getter: Signal<<CheckboxData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<CheckboxData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<bool>,
+        value_setter: SignalSetter<bool>,
     ) -> View {
         let label = control
             .data
@@ -407,11 +394,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn stepper<FD: FormToolData>(
+    fn stepper(
         &self,
         control: Rc<ControlRenderData<Self, StepperData>>,
-        value_getter: Signal<<StepperData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<StepperData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let view = view! {
@@ -425,9 +412,9 @@ impl FormStyle for GridFormStyle {
                 type="number"
                 id=&control.data.name
                 name=&control.data.name
-                step=control.data.step
-                min=control.data.min
-                max=control.data.max
+                step=control.data.step.clone()
+                min=control.data.min.clone()
+                max=control.data.max.clone()
                 class="form_input"
                 class=("form_input_invalid", move || validation_state.get().is_err())
                 prop:value=move || value_getter.get()
@@ -441,11 +428,11 @@ impl FormStyle for GridFormStyle {
         self.custom_component(&control.styles, view)
     }
 
-    fn slider<FD: FormToolData>(
+    fn slider(
         &self,
         control: Rc<ControlRenderData<Self, SliderData>>,
-        value_getter: Signal<<SliderData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<SliderData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View {
         let view = view! {
@@ -459,16 +446,14 @@ impl FormStyle for GridFormStyle {
                 type="range"
                 id=&control.data.name
                 name=&control.data.name
-                min=control.data.min
-                max=control.data.max
+                min=control.data.min.clone()
+                max=control.data.max.clone()
                 class="form_input"
                 class=("form_input_invalid", move || validation_state.get().is_err())
                 prop:value=move || value_getter.get()
                 on:input=move |ev| {
-                    let value = event_target_value(&ev).parse::<i32>().ok();
-                    if let Some(value) = value {
-                        value_setter.set(value);
-                    }
+                    let value = event_target_value(&ev);
+                    value_setter.set(value);
                 }
             />
         }

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -1,23 +1,10 @@
 mod grid_form;
 
-use crate::{
-    controls::{
-        button::ButtonData,
-        checkbox::CheckboxData,
-        heading::HeadingData,
-        hidden::HiddenData,
-        output::OutputData,
-        radio_buttons::RadioButtonsData,
-        select::{SelectBuildData, SelectData},
-        slider::SliderData,
-        spacer::SpacerData,
-        stepper::StepperData,
-        submit::SubmitData,
-        text_area::TextAreaData,
-        text_input::TextInputData,
-        ControlData, ControlRenderData, ValidationState,
-    },
-    FormToolData,
+use crate::controls::{
+    button::ButtonData, checkbox::CheckboxData, heading::HeadingData, hidden::HiddenData,
+    output::OutputData, radio_buttons::RadioButtonsData, select::SelectData, slider::SliderData,
+    spacer::SpacerData, stepper::StepperData, submit::SubmitData, text_area::TextAreaData,
+    text_input::TextInputData, ControlRenderData, ValidationState,
 };
 use leptos::{Signal, SignalSetter, View};
 use std::rc::Rc;
@@ -113,76 +100,76 @@ pub trait FormStyle: 'static {
     /// Renders a text input control.
     ///
     /// See [`TextInputData`].
-    fn text_input<FD: FormToolData>(
+    fn text_input(
         &self,
         control: Rc<ControlRenderData<Self, TextInputData>>,
-        value_getter: Signal<<TextInputData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<TextInputData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a text area control.
     ///
     /// See [`TextAreaData`].
-    fn text_area<FD: FormToolData>(
+    fn text_area(
         &self,
         control: Rc<ControlRenderData<Self, TextAreaData>>,
-        value_getter: Signal<<TextAreaData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<TextAreaData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a group of radio buttons.
     ///
     /// See [`RadioButtonsData`].
-    fn radio_buttons<FD: FormToolData>(
+    fn radio_buttons(
         &self,
         control: Rc<ControlRenderData<Self, RadioButtonsData>>,
-        value_getter: Signal<<RadioButtonsData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<RadioButtonsData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a select (or dropdown) control.
     ///
     /// See [`SelectData`].
-    fn select<FD: FormToolData>(
+    fn select(
         &self,
         control: Rc<ControlRenderData<Self, SelectData>>,
-        value_getter: Signal<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a checkbox control.
     ///
     /// See [`CheckboxData`].
-    fn checkbox<FD: FormToolData>(
+    fn checkbox(
         &self,
         control: Rc<ControlRenderData<Self, CheckboxData>>,
-        value_getter: Signal<<CheckboxData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<CheckboxData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<bool>,
+        value_setter: SignalSetter<bool>,
     ) -> View;
 
     /// Renders a stepper control.
     ///
     /// See [`StepperData`].
-    fn stepper<FD: FormToolData>(
+    fn stepper(
         &self,
         control: Rc<ControlRenderData<Self, StepperData>>,
-        value_getter: Signal<<StepperData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<StepperData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a slider control.
     ///
     /// See [`SliderData`].
-    fn slider<FD: FormToolData>(
+    fn slider(
         &self,
         control: Rc<ControlRenderData<Self, SliderData>>,
-        value_getter: Signal<<SliderData as ControlData<FD>>::ReturnType>,
-        value_setter: SignalSetter<<SliderData as ControlData<FD>>::ReturnType>,
+        value_getter: Signal<String>,
+        value_setter: SignalSetter<String>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 }

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -2,15 +2,24 @@ mod grid_form;
 
 use crate::{
     controls::{
-        button::ButtonData, checkbox::CheckboxData, heading::HeadingData, hidden::HiddenData,
-        output::OutputData, radio_buttons::RadioButtonsData, select::SelectData,
-        slider::SliderData, spacer::SpacerData, stepper::StepperData, submit::SubmitData,
-        text_area::TextAreaData, text_input::TextInputData, ControlData, ControlRenderData,
-        ValidationState,
+        button::ButtonData,
+        checkbox::CheckboxData,
+        heading::HeadingData,
+        hidden::HiddenData,
+        output::OutputData,
+        radio_buttons::RadioButtonsData,
+        select::{SelectBuildData, SelectData},
+        slider::SliderData,
+        spacer::SpacerData,
+        stepper::StepperData,
+        submit::SubmitData,
+        text_area::TextAreaData,
+        text_input::TextInputData,
+        ControlData, ControlRenderData, ValidationState,
     },
     FormToolData,
 };
-use leptos::{RwSignal, Signal, SignalSetter, View};
+use leptos::{Signal, SignalSetter, View};
 use std::rc::Rc;
 
 pub use grid_form::{GFStyleAttr, GridFormStyle};
@@ -24,7 +33,7 @@ pub trait FormStyle: 'static {
     /// The type of styling attributes that this [`FormStyle`] takes.
     ///
     /// These styling attributes can be applied to any of the controls.
-    type StylingAttributes;
+    type StylingAttributes: Clone;
 
     /// Render any containing components for the form.
     ///
@@ -77,10 +86,9 @@ pub trait FormStyle: 'static {
     /// Renders a button.
     ///
     /// See [`ButtonData`]
-    fn button<FD: FormToolData>(
+    fn button(
         &self,
-        control: Rc<ControlRenderData<Self, ButtonData<FD>>>,
-        data_signal: RwSignal<FD>,
+        control: Rc<ControlRenderData<Self, ButtonData>>,
         value_getter: Option<Signal<String>>,
     ) -> View;
 
@@ -105,76 +113,76 @@ pub trait FormStyle: 'static {
     /// Renders a text input control.
     ///
     /// See [`TextInputData`].
-    fn text_input(
+    fn text_input<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, TextInputData>>,
-        value_getter: Signal<<TextInputData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<TextInputData as ControlData>::ReturnType>,
+        value_getter: Signal<<TextInputData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<TextInputData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a text area control.
     ///
     /// See [`TextAreaData`].
-    fn text_area(
+    fn text_area<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, TextAreaData>>,
-        value_getter: Signal<<TextAreaData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<TextAreaData as ControlData>::ReturnType>,
+        value_getter: Signal<<TextAreaData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<TextAreaData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a group of radio buttons.
     ///
     /// See [`RadioButtonsData`].
-    fn radio_buttons(
+    fn radio_buttons<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, RadioButtonsData>>,
-        value_getter: Signal<<RadioButtonsData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<RadioButtonsData as ControlData>::ReturnType>,
+        value_getter: Signal<<RadioButtonsData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<RadioButtonsData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a select (or dropdown) control.
     ///
     /// See [`SelectData`].
-    fn select(
+    fn select<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, SelectData>>,
-        value_getter: Signal<<SelectData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<SelectData as ControlData>::ReturnType>,
+        value_getter: Signal<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<SelectBuildData<FD> as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a checkbox control.
     ///
     /// See [`CheckboxData`].
-    fn checkbox(
+    fn checkbox<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, CheckboxData>>,
-        value_getter: Signal<<CheckboxData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<CheckboxData as ControlData>::ReturnType>,
+        value_getter: Signal<<CheckboxData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<CheckboxData as ControlData<FD>>::ReturnType>,
     ) -> View;
 
     /// Renders a stepper control.
     ///
     /// See [`StepperData`].
-    fn stepper(
+    fn stepper<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, StepperData>>,
-        value_getter: Signal<<StepperData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<StepperData as ControlData>::ReturnType>,
+        value_getter: Signal<<StepperData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<StepperData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 
     /// Renders a slider control.
     ///
     /// See [`SliderData`].
-    fn slider(
+    fn slider<FD: FormToolData>(
         &self,
         control: Rc<ControlRenderData<Self, SliderData>>,
-        value_getter: Signal<<SliderData as ControlData>::ReturnType>,
-        value_setter: SignalSetter<<SliderData as ControlData>::ReturnType>,
+        value_getter: Signal<<SliderData as ControlData<FD>>::ReturnType>,
+        value_setter: SignalSetter<<SliderData as ControlData<FD>>::ReturnType>,
         validation_state: Signal<ValidationState>,
     ) -> View;
 }


### PR DESCRIPTION
Renamed `build_control` to `render_control` in the `ControlData` traits.

Select options can now be based on other form data fields.

To do this, I could to do something similar to the button and create a `SelectBuilder` struct because with the normal `ControlBuilder`, you don't have access to the `FormToolData` (`FD`) signal.

Instead of having the button and select be exceptions, I changed it to be the rule. The `render_control` (formerly `build_control`) method of the `ControlData` traits now takes the form data signal. This means the select and button controls are no longer exceptions to the rule.

An unfortunate side effect is that the `ControlData` traits now needs to be generic on `FD`.
